### PR TITLE
Use --target=ES6 with --module=CommonJs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,6 @@
-import express from 'express';
+"use strict";
+
+import express = require('express');
 let app = express();
+
+console.log(typeof app);

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "express": "^4.13.3"
   },
   "devDependencies": {
+    "typescript": "next",
     "babel-preset-es2015": "^6.0.15"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "target": "es6",
+        "module": "commonjs",
         "noImplicitAny": false,
         "outDir": "built",
         "rootDir": ".",


### PR DESCRIPTION
Since express does not have a defualt export, and node v.4/5 does not support ES6 modules yet, convert the sample to use --target=ES6 and --module=commonJs.

also use `import express = require("express")` to allow for loading old style node modules.
